### PR TITLE
security: disable postinstall/lifecycle scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
## Why
Lifecycle scripts (`postinstall`, `prepare`, etc.) run arbitrary code during
`npm install` / `yarn install` and are a common supply-chain attack vector.

## What changed
- `.npmrc` → `ignore-scripts=true`
- `.yarnrc` → `ignore-scripts true`  *(Yarn Classic repos only)*
- `.yarnrc.yml` → `enableScripts: false`  *(Yarn Berry repos only)*

## References
- [npm docs — ignore-scripts](https://docs.npmjs.com/cli/v10/using-npm/scripts)
- [Yarn Berry — enableScripts](https://yarnpkg.com/configuration/yarnrc#enableScripts)

> Opened automatically by `bulk_disable_scripts.py` — ping #security with questions.
